### PR TITLE
Improve stability by exiting immediately on common errors

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -8,7 +8,9 @@ use tracing::{error, info, info_span, warn, Instrument};
 use uuid::Uuid;
 
 use crate::auth::Authenticator;
-use crate::shared::{proxy, recv_json, send_json, ClientMessage, ServerMessage, CONTROL_PORT};
+use crate::shared::{
+    proxy, recv_json, recv_json_timeout, send_json, ClientMessage, ServerMessage, CONTROL_PORT,
+};
 
 /// State structure for the client.
 pub struct Client {
@@ -42,7 +44,7 @@ impl Client {
         }
 
         send_json(&mut stream, ClientMessage::Hello(port)).await?;
-        let remote_port = match recv_json(&mut stream, &mut Vec::new()).await? {
+        let remote_port = match recv_json_timeout(&mut stream).await? {
             Some(ServerMessage::Hello(remote_port)) => remote_port,
             Some(ServerMessage::Error(message)) => bail!("server error: {message}"),
             Some(ServerMessage::Challenge(_)) => {

--- a/src/client.rs
+++ b/src/client.rs
@@ -3,13 +3,14 @@
 use std::sync::Arc;
 
 use anyhow::{bail, Context, Result};
-use tokio::{io::BufReader, net::TcpStream};
+use tokio::{io::BufReader, net::TcpStream, time::timeout};
 use tracing::{error, info, info_span, warn, Instrument};
 use uuid::Uuid;
 
 use crate::auth::Authenticator;
 use crate::shared::{
     proxy, recv_json, recv_json_timeout, send_json, ClientMessage, ServerMessage, CONTROL_PORT,
+    NETWORK_TIMEOUT,
 };
 
 /// State structure for the client.
@@ -33,10 +34,7 @@ pub struct Client {
 impl Client {
     /// Create a new client.
     pub async fn new(local_port: u16, to: &str, port: u16, secret: Option<&str>) -> Result<Self> {
-        let stream = TcpStream::connect((to, CONTROL_PORT))
-            .await
-            .with_context(|| format!("could not connect to {to}:{CONTROL_PORT}"))?;
-        let mut stream = BufReader::new(stream);
+        let mut stream = BufReader::new(connect_with_timeout(to, CONTROL_PORT).await?);
 
         let auth = secret.map(Authenticator::new);
         if let Some(auth) = &auth {
@@ -101,21 +99,23 @@ impl Client {
     }
 
     async fn handle_connection(&self, id: Uuid) -> Result<()> {
-        let mut remote_conn = BufReader::new(
-            TcpStream::connect((&self.to[..], CONTROL_PORT))
-                .await
-                .context("failed TCP connection to remote port")?,
-        );
+        let mut remote_conn =
+            BufReader::new(connect_with_timeout(&self.to[..], CONTROL_PORT).await?);
         if let Some(auth) = &self.auth {
             auth.client_handshake(&mut remote_conn).await?;
         }
         send_json(&mut remote_conn, ClientMessage::Accept(id)).await?;
 
-        let local_conn = TcpStream::connect(("localhost", self.local_port))
-            .await
-            .context("failed TCP connection to local port")?;
-
+        let local_conn = connect_with_timeout("localhost", self.local_port).await?;
         proxy(local_conn, remote_conn).await?;
         Ok(())
     }
+}
+
+async fn connect_with_timeout(to: &str, port: u16) -> Result<TcpStream> {
+    match timeout(NETWORK_TIMEOUT, TcpStream::connect((to, port))).await {
+        Ok(res) => res,
+        Err(err) => Err(err.into()),
+    }
+    .with_context(|| format!("could not connect to {to}:{port}"))
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -13,7 +13,9 @@ use tracing::{info, info_span, warn, Instrument};
 use uuid::Uuid;
 
 use crate::auth::Authenticator;
-use crate::shared::{proxy, recv_json, send_json, ClientMessage, ServerMessage, CONTROL_PORT};
+use crate::shared::{
+    proxy, recv_json_timeout, send_json, ClientMessage, ServerMessage, CONTROL_PORT,
+};
 
 /// State structure for the server.
 pub struct Server {
@@ -71,10 +73,7 @@ impl Server {
             }
         }
 
-        let mut buf = Vec::new();
-        let msg = recv_json(&mut stream, &mut buf).await?;
-
-        match msg {
+        match recv_json_timeout(&mut stream).await? {
             Some(ClientMessage::Authenticate(_)) => {
                 warn!("unexpected authenticate");
                 Ok(())

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -49,10 +49,10 @@ where
 {
     let (mut s1_read, mut s1_write) = io::split(stream1);
     let (mut s2_read, mut s2_write) = io::split(stream2);
-    tokio::try_join!(
-        io::copy(&mut s1_read, &mut s2_write),
-        io::copy(&mut s2_read, &mut s1_write),
-    )?;
+    tokio::select! {
+        res = io::copy(&mut s1_read, &mut s2_write) => res,
+        res = io::copy(&mut s2_read, &mut s1_write) => res,
+    }?;
     Ok(())
 }
 

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -13,6 +13,9 @@ use uuid::Uuid;
 /// TCP port used for control connections with the server.
 pub const CONTROL_PORT: u16 = 7835;
 
+/// Timeout for network connections and initial protocol messages.
+pub const NETWORK_TIMEOUT: Duration = Duration::from_secs(3);
+
 /// A message from the client on the control connection.
 #[derive(Debug, Serialize, Deserialize)]
 pub enum ClientMessage {
@@ -84,8 +87,7 @@ pub async fn recv_json<T: DeserializeOwned>(
 pub async fn recv_json_timeout<T: DeserializeOwned>(
     reader: &mut (impl AsyncBufRead + Unpin),
 ) -> Result<Option<T>> {
-    const TIMEOUT: Duration = Duration::from_secs(3);
-    timeout(TIMEOUT, recv_json(reader, &mut Vec::new()))
+    timeout(NETWORK_TIMEOUT, recv_json(reader, &mut Vec::new()))
         .await
         .context("timed out waiting for initial message")?
 }

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -7,6 +7,7 @@ use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use tokio::io::{self, AsyncBufRead, AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt};
 use tokio::time::timeout;
+use tracing::trace;
 use uuid::Uuid;
 
 /// TCP port used for control connections with the server.
@@ -64,6 +65,7 @@ pub async fn recv_json<T: DeserializeOwned>(
     reader: &mut (impl AsyncBufRead + Unpin),
     buf: &mut Vec<u8>,
 ) -> Result<Option<T>> {
+    trace!("waiting to receive json message");
     buf.clear();
     reader.read_until(0, buf).await?;
     if buf.is_empty() {
@@ -90,6 +92,7 @@ pub async fn recv_json_timeout<T: DeserializeOwned>(
 
 /// Send a null-terminated JSON instruction on a stream.
 pub async fn send_json<T: Serialize>(writer: &mut (impl AsyncWrite + Unpin), msg: T) -> Result<()> {
+    trace!("sending json message");
     let msg = serde_json::to_vec(&msg)?;
     writer.write_all(&msg).await?;
     writer.write_all(&[0]).await?;


### PR DESCRIPTION
This PR improves stability and user experience by terminating, instead of waiting indefinitely, in the following cases:

**Kill connections in the `shared::proxy()` function when either duplex stream direction terminates, rather than both.**

For example, if a user starts a connection at `bore.pub:12345` that forwards a raw HTTP/2 connection to their localhost port, and they kill the web server at that port, then previously future HTTP/2 requests in the same browser session to `bore.pub:12345` would hang indefinitely because they would reuse the same TCP stream. With this change, the TCP stream would be closed immediately instead.

**Adds a timeout to initial protocol messages.**

Initial protocol messages should be expected immediately, so if they are not sent, that indicates a network partition or other issue. This adds a timeout to such messages. It catches cases such as when the `-s` flag is passed to `bore local` even when the server is configured to not use a secret. Previously this case would wait indefinitely for a server challenge.

**Adds a timeout to initial TCP connections.**

This fixes issues such as typo in the TCP connection string. Previously running something like `bore local 5000 --to google.com` would wait indefinitely for a connection to `google.com:7835`. Now it terminates gracefully with an error.