### PR TITLE
Add a configuration to allow forward to a different local host

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ You can forward a port on your local machine by using the `bore local` command. 
 bore local 5000 --to bore.pub
 ```
 
-You can optionally pass in a `--port` option to pick a specific port on the remote to expose, although the command will fail if this port is not available.
+You can optionally pass in a `--port` option to pick a specific port on the remote to expose, although the command will fail if this port is not available. Also, passing `--local-host` allows you to expose a different host on your local area network besides the loopback address `localhost`.
 
 The full options are shown below.
 
@@ -59,15 +59,15 @@ USAGE:
     bore local [OPTIONS] --to <TO> <LOCAL_PORT>
 
 ARGS:
-    <LOCAL_PORT>    The local port to connect to
+    <LOCAL_PORT>    The local port to expose
 
 OPTIONS:
-    -h, --help                       Print help information
-    -l, --local-host <LOCAL_HOST>    The local host to connect to [default: localhost]
-    -p, --port <PORT>                Optional port on the remote server to select [default: 0]
-    -s, --secret <SECRET>            Optional secret for authentication
-    -t, --to <TO>                    Address of the remote server to expose local ports to
-    -V, --version                    Print version information
+    -h, --help                 Print help information
+    -l, --local-host <HOST>    The local host to expose [default: localhost]
+    -p, --port <PORT>          Optional port on the remote server to select [default: 0]
+    -s, --secret <SECRET>      Optional secret for authentication
+    -t, --to <TO>              Address of the remote server to expose local ports to
+    -V, --version              Print version information
 ```
 
 ### Self-Hosting

--- a/README.md
+++ b/README.md
@@ -59,14 +59,15 @@ USAGE:
     bore local [OPTIONS] --to <TO> <LOCAL_PORT>
 
 ARGS:
-    <LOCAL_PORT>    The local port to listen on
+    <LOCAL_PORT>    The local port to connect to
 
 OPTIONS:
-    -h, --help               Print help information
-    -p, --port <PORT>        Optional port on the remote server to select [default: 0]
-    -s, --secret <SECRET>    Optional secret for authentication
-    -t, --to <TO>            Address of the remote server to expose local ports to
-    -V, --version            Print version information
+    -h, --help                       Print help information
+    -l, --local-host <LOCAL_HOST>    The local host to connect to [default: localhost]
+    -p, --port <PORT>                Optional port on the remote server to select [default: 0]
+    -s, --secret <SECRET>            Optional secret for authentication
+    -t, --to <TO>                    Address of the remote server to expose local ports to
+    -V, --version                    Print version information
 ```
 
 ### Self-Hosting

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,11 +14,11 @@ struct Args {
 enum Command {
     /// Starts a local proxy to the remote server.
     Local {
-        /// The local port to connect to.
+        /// The local port to expose.
         local_port: u16,
 
-        /// The local host to connect to.
-        #[clap(short, long, default_value = "localhost")]
+        /// The local host to expose.
+        #[clap(short, long, value_name = "HOST", default_value = "localhost")]
         local_host: String,
 
         /// Address of the remote server to expose local ports to.

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,8 +14,12 @@ struct Args {
 enum Command {
     /// Starts a local proxy to the remote server.
     Local {
-        /// The local port to listen on.
+        /// The local port to connect to.
         local_port: u16,
+
+        /// The local host to connect to.
+        #[clap(short, long, default_value = "localhost")]
+        local_host: String,
 
         /// Address of the remote server to expose local ports to.
         #[clap(short, long)]
@@ -49,12 +53,13 @@ async fn main() -> Result<()> {
     let args = Args::parse();
     match args.command {
         Command::Local {
+            local_host,
             local_port,
             to,
             port,
             secret,
         } => {
-            let client = Client::new(local_port, &to, port, secret.as_deref()).await?;
+            let client = Client::new(&local_host, local_port, &to, port, secret.as_deref()).await?;
             client.listen().await?;
         }
         Command::Server { min_port, secret } => {

--- a/tests/e2e_test.rs
+++ b/tests/e2e_test.rs
@@ -24,7 +24,14 @@ async fn spawn_server(secret: Option<&str>) {
 /// Spawns a client with randomly assigned ports, returning the listener and remote address.
 async fn spawn_client(secret: Option<&str>) -> Result<(TcpListener, SocketAddr)> {
     let listener = TcpListener::bind("localhost:0").await?;
-    let client = Client::new(listener.local_addr()?.port(), "localhost", 0, secret).await?;
+    let client = Client::new(
+        "localhost",
+        listener.local_addr()?.port(),
+        "localhost",
+        0,
+        secret,
+    )
+    .await?;
     let remote_addr = ([0, 0, 0, 0], client.remote_port()).into();
     tokio::spawn(client.listen());
     Ok((listener, remote_addr))
@@ -83,7 +90,7 @@ async fn mismatched_secret(
 async fn invalid_address() -> Result<()> {
     // We don't need the serial guard for this test because it doesn't create a server.
     async fn check_address(to: &str, use_secret: bool) -> Result<()> {
-        match Client::new(5000, to, 0, use_secret.then(|| "a secret")).await {
+        match Client::new("localhost", 5000, to, 0, use_secret.then(|| "a secret")).await {
             Ok(_) => Err(anyhow!("expected error for {to}, use_secret={use_secret}")),
             Err(_) => Ok(()),
         }

--- a/tests/e2e_test.rs
+++ b/tests/e2e_test.rs
@@ -24,14 +24,8 @@ async fn spawn_server(secret: Option<&str>) {
 /// Spawns a client with randomly assigned ports, returning the listener and remote address.
 async fn spawn_client(secret: Option<&str>) -> Result<(TcpListener, SocketAddr)> {
     let listener = TcpListener::bind("localhost:0").await?;
-    let client = Client::new(
-        "localhost",
-        listener.local_addr()?.port(),
-        "localhost",
-        0,
-        secret,
-    )
-    .await?;
+    let local_port = listener.local_addr()?.port();
+    let client = Client::new("localhost", local_port, "localhost", 0, secret).await?;
     let remote_addr = ([0, 0, 0, 0], client.remote_port()).into();
     tokio::spawn(client.listen());
     Ok((listener, remote_addr))


### PR DESCRIPTION
Adds the ability to provide a different host to forward connections to. Closes #14.

Can test with the following:

```bash
# Start a tunnel proxying a port to httpbin.org:80
cargo run local --to bore.pub -l httpbin.org 80
```

```bash
# Access a url that httpbin.org:80 exposes
curl -vvv http://bore.pub:<port>/anything
```