### PR TITLE
Support reading client/server secret from an environment variable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = { version = "1.0.56", features = ["backtrace"] }
-clap = { version = "3.1.8", features = ["derive"] }
+clap = { version = "3.1.8", features = ["derive", "env"] }
 dashmap = "5.2.0"
 hex = "0.4.3"
 hmac = "0.12.1"

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ OPTIONS:
     -h, --help                 Print help information
     -l, --local-host <HOST>    The local host to expose [default: localhost]
     -p, --port <PORT>          Optional port on the remote server to select [default: 0]
-    -s, --secret <SECRET>      Optional secret for authentication
+    -s, --secret <SECRET>      Optional secret for authentication [env: BORE_SECRET]
     -t, --to <TO>              Address of the remote server to expose local ports to
     -V, --version              Print version information
 ```
@@ -92,7 +92,7 @@ USAGE:
 OPTIONS:
     -h, --help                   Print help information
         --min-port <MIN_PORT>    Minimum TCP port number to accept [default: 1024]
-    -s, --secret <SECRET>        Optional secret for authentication
+    -s, --secret <SECRET>        Optional secret for authentication [env: BORE_SECRET]
     -V, --version                Print version information
 ```
 
@@ -115,6 +115,8 @@ bore server --secret my_secret_string
 # on the client
 bore local <LOCAL_PORT> --to <TO> --secret my_secret_string
 ```
+
+`BORE_SECRET` environment variable can also be used for setting the secret for client/server.
 
 ## Acknowledgements
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,7 @@ enum Command {
         port: u16,
 
         /// Optional secret for authentication.
-        #[clap(short, long)]
+        #[clap(short, long, env = "BORE_SECRET", hide_env_values = true)]
         secret: Option<String>,
     },
 
@@ -41,7 +41,7 @@ enum Command {
         min_port: u16,
 
         /// Optional secret for authentication.
-        #[clap(short, long)]
+        #[clap(short, long, env = "BORE_SECRET", hide_env_values = true)]
         secret: Option<String>,
     },
 }


### PR DESCRIPTION
This PR adds `env` feature to `clap` for defining custom variables to read the values of `--secret` arguments from the environment.

- `BORE_SECRET`: sets the client/server secret

closes #17
