### PR TITLE
Change server behavior when port by local is set to 0

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -62,26 +62,25 @@ impl Server {
     }
 
     /// Create new TcpListener and return it, if port is set to 0 then in sequence search for unused port in range
-    async fn create_listener(port:u16,min_port:u16) -> Option<TcpListener> {
+    async fn create_listener(port: u16, min_port: u16) -> Option<TcpListener> {
         if port == 0 {
             for port in min_port..65535 {
                 match TcpListener::bind(("0.0.0.0", port)).await {
                     Ok(l) => return Some(l),
-                    Err(_) => continue
+                    Err(_) => continue,
                 }
             }
             // Check the last port as loop does not include it
             match TcpListener::bind(("0.0.0.0", 65535)).await {
-                Ok(l) => return Some(l),
-                Err(_) => return None
+                Ok(l) => Some(l),
+                Err(_) => None,
             }
         } else {
             match TcpListener::bind(("0.0.0.0", port)).await {
-                Ok(l) => return Some(l),
-                Err(_) => {}
+                Ok(l) => Some(l),
+                Err(_) => None,
             }
         }
-        return None;
     }
 
     async fn handle_connection(&self, stream: TcpStream) -> Result<()> {


### PR DESCRIPTION
Server will search for unused port within range of min_port and assign it to local
If there is no available port it will throw an error

Resolves #23 and gives easy way to implement max port which is my next plan

I tested it on linux and windows and everything seems to work great.
If the quality of the code needs to be tweaked feel free to tell me. I am quite new to rust. Unfortunately I'm going away for the weekend so most likely I will be able to do possible corrections on Monday or Tuesday