### PR TITLE
Fix Windows cargo test

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -84,7 +84,7 @@ impl Server {
                     return Ok(());
                 }
                 info!(?port, "new client");
-                let listener = match TcpListener::bind(("::", port)).await {
+                let listener = match TcpListener::bind(("0.0.0.0", port)).await {
                     Ok(listener) => listener,
                     Err(_) => {
                         warn!(?port, "could not bind to local port");

--- a/tests/e2e_test.rs
+++ b/tests/e2e_test.rs
@@ -26,7 +26,7 @@ async fn spawn_client(secret: Option<&str>) -> Result<(TcpListener, SocketAddr)>
     let listener = TcpListener::bind("localhost:0").await?;
     let local_port = listener.local_addr()?.port();
     let client = Client::new("localhost", local_port, "localhost", 0, secret).await?;
-    let remote_addr = ([0, 0, 0, 0], client.remote_port()).into();
+    let remote_addr = ([127, 0, 0, 1], client.remote_port()).into();
     tokio::spawn(client.listen());
     Ok((listener, remote_addr))
 }


### PR DESCRIPTION
As the title says the changes are fixing cargo test on Windows.

I tested it on VM and with CI config from #10 and you can see [here](https://github.com/BxOxSxS/bore/actions/runs/2196722647) that it's working fine