### PR TITLE
Improves server min/max port range

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,6 +84,7 @@ dependencies = [
  "hex",
  "hmac",
  "lazy_static",
+ "rand",
  "rstest",
  "serde",
  "serde_json",
@@ -437,6 +438,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -476,6 +483,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ dashmap = "5.2.0"
 futures-util = { version = "0.3.21", features = ["sink"] }
 hex = "0.4.3"
 hmac = "0.12.1"
+rand = "0.8.5"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"
 sha2 = "0.10.2"

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Usage: bore server [OPTIONS]
 
 Options:
       --min-port <MIN_PORT>  Minimum TCP port number to accept [default: 1024]
+      --max-port <MAX_PORT>  Maximum TCP port number to accept [default: 65535]
   -s, --secret <SECRET>      Optional secret for authentication [env: BORE_SECRET]
   -h, --help                 Print help information
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,6 +38,10 @@ enum Command {
         /// Minimum TCP port number to accept.
         #[clap(long, default_value_t = 1024)]
         min_port: u16,
+        
+        /// Minimum TCP port number to accept.
+        #[clap(long, default_value_t = 65535)]
+        max_port: u16,
 
         /// Optional secret for authentication.
         #[clap(short, long, env = "BORE_SECRET", hide_env_values = true)]
@@ -58,8 +62,8 @@ async fn run(command: Command) -> Result<()> {
             let client = Client::new(&local_host, local_port, &to, port, secret.as_deref()).await?;
             client.listen().await?;
         }
-        Command::Server { min_port, secret } => {
-            Server::new(min_port, secret.as_deref()).listen().await?;
+        Command::Server { min_port, max_port, secret } => {
+            Server::new(min_port, max_port,  secret.as_deref()).listen().await?;
         }
     }
 


### PR DESCRIPTION
- Adds a simple LFSR RNG which can generate all ports in the [min_port, max_port] range in random order for each client connection
- Uses an LFSR per client to attempt binding ports until one is bound
- If the client connected without a port request, only returns failure if all ports in the range are already bound
- If client requests a port, it is checked against both min and max