### PR TITLE
Use random ports when port number is 0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,7 @@ dependencies = [
  "anyhow",
  "clap",
  "dashmap",
+ "fastrand",
  "futures-util",
  "hex",
  "hmac",
@@ -194,6 +195,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -298,6 +308,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ path = "src/main.rs"
 anyhow = { version = "1.0.56", features = ["backtrace"] }
 clap = { version = "4.0.22", features = ["derive", "env"] }
 dashmap = "5.2.0"
+fastrand = "1.9.0"
 futures-util = { version = "0.3.21", features = ["sink"] }
 hex = "0.4.3"
 hmac = "0.12.1"

--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ Runs the remote proxy server
 Usage: bore server [OPTIONS]
 
 Options:
-      --min-port <MIN_PORT>  Minimum TCP port number to accept [default: 1024]
+      --min-port <MIN_PORT>  Minimum accepted TCP port number [default: 1024]
+      --max-port <MAX_PORT>  Maximum accepted TCP port number [default: 65535]
   -s, --secret <SECRET>      Optional secret for authentication [env: BORE_SECRET]
   -h, --help                 Print help information
 ```

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This will expose your local port at `localhost:8000` to the public internet at `
 
 Similar to [localtunnel](https://github.com/localtunnel/localtunnel) and [ngrok](https://ngrok.io/), except `bore` is intended to be a highly efficient, unopinionated tool for forwarding TCP traffic that is simple to install and easy to self-host, with no frills attached.
 
-(`bore` totals less than 400 lines of safe, async Rust code and is trivial to set up — just run a single binary for the client and server.)
+(`bore` totals about 400 lines of safe, async Rust code and is trivial to set up — just run a single binary for the client and server.)
 
 ## Installation
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -3,9 +3,7 @@
 use std::sync::Arc;
 
 use anyhow::{bail, Context, Result};
-
-use tokio::io::AsyncWriteExt;
-use tokio::{net::TcpStream, time::timeout};
+use tokio::{io::AsyncWriteExt, net::TcpStream, time::timeout};
 use tracing::{error, info, info_span, warn, Instrument};
 use uuid::Uuid;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,7 @@ enum Command {
 
     /// Runs the remote proxy server.
     Server {
-        /// Minimum TCP port number to accept.
+        /// Minimum accepted TCP port number.
         #[clap(long, default_value_t = 1024)]
         min_port: u16,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use bore_cli::{client::Client, server::Server};
-use clap::{Parser, Subcommand};
+use clap::{error::ErrorKind, CommandFactory, Parser, Subcommand};
 
 #[derive(Parser, Debug)]
 #[clap(author, version, about)]
@@ -39,6 +39,10 @@ enum Command {
         #[clap(long, default_value_t = 1024)]
         min_port: u16,
 
+        /// Maximum accepted TCP port number.
+        #[clap(long, default_value_t = 65535)]
+        max_port: u16,
+
         /// Optional secret for authentication.
         #[clap(short, long, env = "BORE_SECRET", hide_env_values = true)]
         secret: Option<String>,
@@ -58,8 +62,18 @@ async fn run(command: Command) -> Result<()> {
             let client = Client::new(&local_host, local_port, &to, port, secret.as_deref()).await?;
             client.listen().await?;
         }
-        Command::Server { min_port, secret } => {
-            Server::new(min_port, secret.as_deref()).listen().await?;
+        Command::Server {
+            min_port,
+            max_port,
+            secret,
+        } => {
+            let port_range = min_port..=max_port;
+            if port_range.is_empty() {
+                Args::command()
+                    .error(ErrorKind::InvalidValue, "port range is empty")
+                    .exit();
+            }
+            Server::new(port_range, secret.as_deref()).listen().await?;
         }
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -84,8 +84,8 @@ impl Server {
             // ports are currently available, it suffices to check approximately -2 ln(δ) / ε
             // independently and uniformly chosen ports (up to a second-order term in ε).
             //
-            // Checking 150 times gives us 99.999% success at utilizing 85% of ports under this
-            // bound, when ε=0.5 and δ=0.00001.
+            // Checking 150 times gives us 99.999% success at utilizing 85% of ports under these
+            // conditions, when ε=0.15 and δ=0.00001.
             for _ in 0..150 {
                 let port = fastrand::u16(self.port_range.clone());
                 match try_bind(port).await {

--- a/src/server.rs
+++ b/src/server.rs
@@ -113,11 +113,12 @@ impl Server {
                 Ok(())
             }
             Some(ClientMessage::Hello(port)) => {
-                let Ok(listener) = self.create_listener(port).await else {
-                    stream
-                        .send(ServerMessage::Error("port already in use".into()))
-                        .await?;
-                    return Ok(());
+                let listener = match self.create_listener(port).await {
+                    Ok(listener) => listener,
+                    Err(err) => {
+                        stream.send(ServerMessage::Error(err.into())).await?;
+                        return Ok(());
+                    }
                 };
                 let port = listener.local_addr()?.port();
                 info!(?port, "new client");

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -7,7 +7,6 @@ use futures_util::{SinkExt, StreamExt};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use tokio::io::{self, AsyncRead, AsyncWrite};
-
 use tokio::time::timeout;
 use tokio_util::codec::{AnyDelimiterCodec, Framed, FramedParts};
 use tracing::trace;

--- a/tests/e2e_test.rs
+++ b/tests/e2e_test.rs
@@ -17,7 +17,7 @@ lazy_static! {
 
 /// Spawn the server, giving some time for the control port TcpListener to start.
 async fn spawn_server(secret: Option<&str>) {
-    tokio::spawn(Server::new(1024, secret).listen());
+    tokio::spawn(Server::new(1024..=65535, secret).listen());
     time::sleep(Duration::from_millis(50)).await;
 }
 
@@ -116,4 +116,12 @@ async fn very_long_frame() -> Result<()> {
         time::sleep(Duration::from_millis(10)).await;
     }
     panic!("did not exit after a 1 MB frame");
+}
+
+#[test]
+#[should_panic]
+fn empty_port_range() {
+    let min_port = 5000;
+    let max_port = 3000;
+    let _ = Server::new(min_port..=max_port, None);
 }


### PR DESCRIPTION
With this pull request, we no longer use `bind("0.0.0.0", 0)` from the operating system to choose an arbitrary available port. Instead, we use our own random number generator and retry 150 times. See comments for an explanation of where this constant comes from.

- Resolves #70
- Resolves #75
- Closes #28