### PR TITLE
Fix typo, Maxmium -> Maximum

### DIFF
--- a/src/shared.rs
+++ b/src/shared.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 /// TCP port used for control connections with the server.
 pub const CONTROL_PORT: u16 = 7835;
 
-/// Maxmium byte length for a JSON frame in the stream.
+/// Maximum byte length for a JSON frame in the stream.
 pub const MAX_FRAME_LENGTH: usize = 256;
 
 /// Timeout for network connections and initial protocol messages.


### PR DESCRIPTION
Found via `codespell -L crate`