### PR TITLE
fix dual-stack ipv6 listening on windows, add listen addr option

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -46,6 +46,10 @@ enum Command {
         /// Optional secret for authentication.
         #[clap(short, long, env = "BORE_SECRET", hide_env_values = true)]
         secret: Option<String>,
+        
+        /// Listen Addr.
+        #[clap(short, long, default_value = "[::]")]
+        listen_addr: String,
     },
 }
 
@@ -66,6 +70,7 @@ async fn run(command: Command) -> Result<()> {
             min_port,
             max_port,
             secret,
+            listen_addr,
         } => {
             let port_range = min_port..=max_port;
             if port_range.is_empty() {
@@ -73,7 +78,7 @@ async fn run(command: Command) -> Result<()> {
                     .error(ErrorKind::InvalidValue, "port range is empty")
                     .exit();
             }
-            Server::new(port_range, secret.as_deref()).listen().await?;
+            Server::new(port_range, secret.as_deref(), listen_addr).listen().await?;
         }
     }
 


### PR DESCRIPTION
According to windows document, the sockets only operates over the IPv6 protocol by default, so we need to modify the socket before using it.  
Also `--listen-addr ` option is added to be able to bind on a certain address, default is [::].
Tested on win10 and linux.


Refs:
https://learn.microsoft.com/en-us/windows/win32/winsock/dual-stack-sockets
https://docs.rs/tokio/1.29.1/tokio/net/struct.TcpSocket.html
https://docs.rs/socket2/latest/socket2/struct.Socket.html#method.set_only_v6
