### PR TITLE
Add option to write the assigned port to a file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ hmac = "0.12.1"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"
 sha2 = "0.10.2"
-tokio = { version = "1.17.0", features = ["rt-multi-thread", "io-util", "macros", "net", "time"] }
+tokio = { version = "1.17.0", features = ["rt-multi-thread", "io-util", "macros", "net", "time", "fs"] }
 tokio-util = { version = "0.7.1", features = ["codec"] }
 tracing = "0.1.32"
 tracing-subscriber = "0.3.10"


### PR DESCRIPTION
If invoking `bore` from another process, it is useful to be able to get hold of the remote port that has been assigned.

This patch adds a `--write-port-to` option that takes a path.  When provided, the assigned port will be written to that file after it has been assigned.