### PR TITLE
Feat allow to configure control port

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,11 +68,13 @@ Arguments:
   <LOCAL_PORT>  The local port to expose
 
 Options:
-  -l, --local-host <HOST>  The local host to expose [default: localhost]
-  -t, --to <TO>            Address of the remote server to expose local ports to [env: BORE_SERVER=]
-  -p, --port <PORT>        Optional port on the remote server to select [default: 0]
-  -s, --secret <SECRET>    Optional secret for authentication [env: BORE_SECRET]
-  -h, --help               Print help information
+  -l, --local-host <HOST>            The local host to expose [default: localhost]
+  -t, --to <TO>                      Address of the remote server to expose local ports to [env: BORE_SERVER=]
+  -p, --port <PORT>                  Optional port on the remote server to select [default: 0]
+  -s, --secret <SECRET>              Optional secret for authentication [env: BORE_SECRET]
+  -c, --control-port <CONTROL_PORT>  TCP port used for control connections with the server.
+                                     ATTENTION: This port must be equal on both the client and the server. [env: CONTROL_PORT=] [default: 7835]
+  -h, --help                         Print help
 ```
 
 ### Self-Hosting
@@ -93,10 +95,12 @@ Runs the remote proxy server
 Usage: bore server [OPTIONS]
 
 Options:
-      --min-port <MIN_PORT>  Minimum accepted TCP port number [default: 1024]
-      --max-port <MAX_PORT>  Maximum accepted TCP port number [default: 65535]
-  -s, --secret <SECRET>      Optional secret for authentication [env: BORE_SECRET]
-  -h, --help                 Print help information
+      --min-port <MIN_PORT>          Minimum accepted TCP port number [default: 1024]
+      --max-port <MAX_PORT>          Maximum accepted TCP port number [default: 65535]
+  -s, --secret <SECRET>              Optional secret for authentication [env: BORE_SECRET]
+  -c, --control-port <CONTROL_PORT>  TCP port used for control connections with the server.
+                                     ATTENTION: This port must be equal on both the client and the server. [env: CONTROL_PORT=] [default: 7835]
+  -h, --help                         Print help
 ```
 
 ## Protocol

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ You can optionally pass in a `--port` option to pick a specific port on the remo
 
 The full options are shown below.
 
-```shell
+```
 Starts a local proxy to the remote server
 
 Usage: bore local [OPTIONS] --to <TO> <LOCAL_PORT>
@@ -89,7 +89,7 @@ That's all it takes! After the server starts running at a given address, you can
 
 The full options for the `bore server` command are shown below.
 
-```shell
+```
 Runs the remote proxy server
 
 Usage: bore server [OPTIONS]

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ bore local 5000 --to bore.pub
 
 You can optionally pass in a `--port` option to pick a specific port on the remote to expose, although the command will fail if this port is not available. Also, passing `--local-host` allows you to expose a different host on your local area network besides the loopback address `localhost`.
 
-The full options are shown below.
+The full options are shown below (See `bore local -h`).
 
 ```
 Starts a local proxy to the remote server
@@ -87,7 +87,7 @@ bore server
 
 That's all it takes! After the server starts running at a given address, you can then update the `bore local` command with option `--to <ADDRESS>` to forward a local port to this remote server.
 
-The full options for the `bore server` command are shown below.
+The full options for the `bore server` command are shown below (See `bore server -h`).
 
 ```
 Runs the remote proxy server

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,11 @@ enum Command {
         /// Optional secret for authentication.
         #[clap(short, long, env = "BORE_SECRET", hide_env_values = true)]
         secret: Option<String>,
+
+        /// TCP port used for control connections with the server.
+        /// ATTENTION: This port must be equal on both the client and the server.
+        #[clap(short, long, env = "CONTROL_PORT", default_value_t = 7835, verbatim_doc_comment)]
+        control_port: u16,
     },
 
     /// Runs the remote proxy server.
@@ -46,6 +51,11 @@ enum Command {
         /// Optional secret for authentication.
         #[clap(short, long, env = "BORE_SECRET", hide_env_values = true)]
         secret: Option<String>,
+
+        /// TCP port used for control connections with the server.
+        /// ATTENTION: This port must be equal on both the client and the server.
+        #[clap(short, long, env = "CONTROL_PORT", default_value_t = 7835, verbatim_doc_comment)]
+        control_port: u16,
     },
 }
 
@@ -58,6 +68,7 @@ async fn run(command: Command) -> Result<()> {
             to,
             port,
             secret,
+            control_port,
         } => {
             let client = Client::new(&local_host, local_port, &to, port, secret.as_deref()).await?;
             client.listen().await?;
@@ -66,6 +77,7 @@ async fn run(command: Command) -> Result<()> {
             min_port,
             max_port,
             secret,
+            control_port,
         } => {
             let port_range = min_port..=max_port;
             if port_range.is_empty() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,7 +70,7 @@ async fn run(command: Command) -> Result<()> {
             secret,
             control_port,
         } => {
-            let client = Client::new(&local_host, local_port, &to, port, secret.as_deref()).await?;
+            let client = Client::new(&local_host, local_port, &to, port, secret.as_deref(), control_port).await?;
             client.listen().await?;
         }
         Command::Server {
@@ -85,7 +85,7 @@ async fn run(command: Command) -> Result<()> {
                     .error(ErrorKind::InvalidValue, "port range is empty")
                     .exit();
             }
-            Server::new(port_range, secret.as_deref()).listen().await?;
+            Server::new(port_range, secret.as_deref(), control_port).listen().await?;
         }
     }
 

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -11,9 +11,6 @@ use tokio_util::codec::{AnyDelimiterCodec, Framed, FramedParts};
 use tracing::trace;
 use uuid::Uuid;
 
-/// TCP port used for control connections with the server.
-pub const CONTROL_PORT: u16 = 7835;
-
 /// Maximum byte length for a JSON frame in the stream.
 pub const MAX_FRAME_LENGTH: usize = 256;
 


### PR DESCRIPTION
## Feature added: You can now configure the `control_port` to your liking! :tada:

The `CONTROL_PORT` field was removed from `shared.rs`, and instead, is now a part of the `Server` and `Client` objects.

### **For example:**

If you want to configure `7300` as the control port:

- In the server:

  ```
  bore server -c 7300
  ```

- In the client:

  ```
  bore local <LOCAL_PORT> --to <TO> -p <PORT> -c 7300
  ```

> The default control port is the same `7835` port, as before.
> So if you don't state the the `-c` option, then the control port will remain `7835`.

### The `-h` help menu was updated, in both server and client:

```
bore server -h
```
```
bore client -h
```

I also updated the `README.md`, with the new `-h` output.


---

This will solve https://github.com/ekzhang/bore/issues/48 and other duplicate issues!
