### PR TITLE
Fix CI runners

### DIFF
--- a/.github/workflows/mean_bean_ci.yml
+++ b/.github/workflows/mean_bean_ci.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         channel: [stable]
         target:
-          - x86_64-apple-darwin
+          - aarch64-apple-darwin
 
     steps:
       - name: Setup | Checkout


### PR DESCRIPTION
macos-latest has been switched to use arm64 mac instances