### PR TITLE
Secret can now be read from file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ hmac = "0.12.1"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"
 sha2 = "0.10.2"
-tokio = { version = "1.17.0", features = ["rt-multi-thread", "io-util", "macros", "net", "time"] }
+tokio = { version = "1.17.0", features = ["rt-multi-thread", "io-util", "macros", "net", "time", "fs"] }
 tokio-util = { version = "0.7.1", features = ["codec"] }
 tracing = "0.1.32"
 tracing-subscriber = "0.3.10"

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -13,7 +13,7 @@ pub struct Authenticator(Hmac<Sha256>);
 
 impl Authenticator {
     /// Generate an authenticator from a secret.
-    pub fn new(secret: &str) -> Self {
+    pub fn new(secret: String) -> Self {
         let hashed_secret = Sha256::new().chain_update(secret).finalize();
         Self(Hmac::new_from_slice(&hashed_secret).expect("HMAC can take key of any size"))
     }

--- a/tests/auth_test.rs
+++ b/tests/auth_test.rs
@@ -4,7 +4,7 @@ use tokio::io::{self};
 
 #[tokio::test]
 async fn auth_handshake() -> Result<()> {
-    let auth = Authenticator::new("some secret string");
+    let auth = Authenticator::new(String::from("some secret string"));
 
     let (client, server) = io::duplex(8); // Ensure correctness with limited capacity.
     let mut client = Delimited::new(client);
@@ -20,8 +20,8 @@ async fn auth_handshake() -> Result<()> {
 
 #[tokio::test]
 async fn auth_handshake_fail() {
-    let auth = Authenticator::new("client secret");
-    let auth2 = Authenticator::new("different server secret");
+    let auth = Authenticator::new(String::from("client secret"));
+    let auth2 = Authenticator::new(String::from("different server secret"));
 
     let (client, server) = io::duplex(8); // Ensure correctness with limited capacity.
     let mut client = Delimited::new(client);


### PR DESCRIPTION
In order to implement issue #99 I added the possibility to read the secret from a file (both for the client and the server). The main changes are as follows:
 * **changed structure of client.rs**: before the auth variable would be assigned without checking for the existence of secret, now check first whether secret exists as a variable or if it is a file path (in which case the file is read and its content are processed)

_before:_
``` before, lines 46-49
let auth = secret.map(Authenticator::new);
if let Some(auth) = &auth {
    auth.client_handshake(&mutstream).await?;
    }
```

_after:_
``` after
let secret :Option<String>  = if let Some(var) = filepath {
            let file_content = file_reader(var).await;
            Some(file_content)
        } else if secret.is_some() {
                let secret_string = secret.unwrap();
                Some(secret_string)
        } else {None};

```

* **Changed secret type from &str to String**: This makes it easier to find out whether we have received a path to a file where a secret is stored or the secret itself as a string. The clap crate already returns the environmental variables as String so we remove the necessity to call ".as_deref()" when starting a new instance of Server or Client.
* **file_reader function**: Reading the file and handling the errors (also checks for empty files) is done by the function to avoid cluttering the code and it is put in the shared.rs so that both the client and server can use it
* **Added the fs feature from the tokio crate**
* **Edited the tests to work with the new type:** Just changed the strings to ```String::from(...)```
* **Modified the environmental values**: Adding a secret string or filepath is now done via flags, making it clearer that they are optional and mutually exclusive (in case both are present, filepath has precedence) 

I don't have much experience contributing to open-source projects but I really like the tool and wanted to contribute. If any changes or adjustments are needed I am happy to help. :)