### PR TITLE
feat: create docker image for server only

### DIFF
--- a/.github/workflows/docker-server.yml
+++ b/.github/workflows/docker-server.yml
@@ -1,4 +1,4 @@
-name: Docker
+name: Docker Server
 
 on:
   push:
@@ -17,7 +17,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ekzhang/bore
+          images: ekzhang/bore-server
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -44,7 +44,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          target: bore
+          target: server
 
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,13 @@
-FROM rust:alpine as builder
+FROM rust:alpine AS builder
 WORKDIR /home/rust/src
 RUN apk --no-cache add musl-dev
 COPY . .
 RUN cargo install --path .
 
-FROM scratch
+FROM scratch AS bore
 COPY --from=builder /usr/local/cargo/bin/bore .
 USER 1000:1000
 ENTRYPOINT ["./bore"]
+
+FROM bore AS server
+CMD ["server"]


### PR DESCRIPTION
Trying to deploy using a cloud provider and there was no possibility to add "CMD" as a server and I couldn't start it.

I believe it will be necessary to create the new address "ekzhang/bore-server" in docker hub.