### PR TITLE
Fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:alpine as builder
+FROM rust:alpine AS builder
 WORKDIR /home/rust/src
 RUN apk --no-cache add musl-dev
 COPY . .


### PR DESCRIPTION
If I build with docker like
```
docker build -t bore  .                                                                                                                             
```
it reports an error:
>  1 warning found (use docker --debug to expand):
> - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)

Seems `as` should be in uppercase (or both in lowecase) 🙃 
See also https://docs.docker.com/reference/build-checks/from-as-casing/