### PR TITLE
docs: update installation instructions for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,19 +23,47 @@ Similar to [localtunnel](https://github.com/localtunnel/localtunnel) and [ngrok]
 
 ## Installation
 
-If you're on macOS, `bore` is packaged as a Homebrew core formula.
+### MacOS
+
+`bore` is packaged as a Homebrew core formula.
 
 ```shell
 brew install bore-cli
 ```
 
+### Linux
+
+#### Arch
+
+`bore` is available in the AUR as `bore`.
+
+```shell
+yay -S bore # or your favorite AUR helper
+```
+
+#### Gentoo
+
+`bore` is available in the [gentoo-zh](https://github.com/microcai/gentoo-zh) overlay.
+
+```shell
+sudo eselect repository enable gentoo-zh
+sudo emerge --sync gentoo-zh
+sudo emerge net-proxy/bore
+```
+
+### Binary
+
 Otherwise, the easiest way to install bore is from prebuilt binaries. These are available on the [releases page](https://github.com/ekzhang/bore/releases) for macOS, Windows, and Linux. Just unzip the appropriate file for your platform and move the `bore` executable into a folder on your PATH.
+
+### Cargo
 
 You also can build `bore` from source using [Cargo](https://doc.rust-lang.org/cargo/), the Rust package manager. This command installs the `bore` binary at a user-accessible path.
 
 ```shell
 cargo install bore-cli
 ```
+
+### Docker
 
 We also publish versioned Docker images for each release. The image is built for an AMD 64-bit architecture. They're tagged with the specific version and allow you to run the statically-linked `bore` binary from a minimal "scratch" container.
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ brew install bore-cli
 
 ### Linux
 
-#### Arch
+#### Arch Linux
 
 `bore` is available in the AUR as `bore`.
 
@@ -41,7 +41,7 @@ brew install bore-cli
 yay -S bore # or your favorite AUR helper
 ```
 
-#### Gentoo
+#### Gentoo Linux
 
 `bore` is available in the [gentoo-zh](https://github.com/microcai/gentoo-zh) overlay.
 
@@ -51,7 +51,7 @@ sudo emerge --sync gentoo-zh
 sudo emerge net-proxy/bore
 ```
 
-### Binary
+### Binary distribution
 
 Otherwise, the easiest way to install bore is from prebuilt binaries. These are available on the [releases page](https://github.com/ekzhang/bore/releases) for macOS, Windows, and Linux. Just unzip the appropriate file for your platform and move the `bore` executable into a folder on your PATH.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Similar to [localtunnel](https://github.com/localtunnel/localtunnel) and [ngrok]
 
 ## Installation
 
-### MacOS
+### macOS
 
 `bore` is packaged as a Homebrew core formula.
 
@@ -51,7 +51,7 @@ sudo emerge --sync gentoo-zh
 sudo emerge net-proxy/bore
 ```
 
-### Binary distribution
+### Binary Distribution
 
 Otherwise, the easiest way to install bore is from prebuilt binaries. These are available on the [releases page](https://github.com/ekzhang/bore/releases) for macOS, Windows, and Linux. Just unzip the appropriate file for your platform and move the `bore` executable into a folder on your PATH.
 


### PR DESCRIPTION
I recently packaged this application for the gentoo-zh overlay (https://github.com/microcai/gentoo-zh/pull/6113) and updated the README to assist Gentoo users with installation. 

I also noticed the application is already in the AUR, so I have added Arch Linux installation instructions as well. 

Since I am not familiar with other distributions, I have not included any additional information for them.

Thank you for considering this change!