### PR TITLE
Update Dockerfile: Add curl for healthchecks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM rust:alpine AS builder
 WORKDIR /home/rust/src
 RUN apk --no-cache add musl-dev
+RUN apk --no-cache add curl
 COPY . .
 RUN cargo install --path .
 


### PR DESCRIPTION
This PR simply adds curl to the docker container when it is built, which is needed for health checks such as this:

```compose
healthcheck:
        test: curl -f http://ip-address/ || exit 1
        interval: 7s
        timeout: 60s
        retries: 2
```

This will allow a container to optionally monitor itself (if the remote endpoint is public) when the user configures it to do so. This is the most ideal solution for checking if a system is still working, so i hope it gets accepted.