### PR TITLE
Add configurable control/tunnel addresses for the server

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ bore server
 
 That's all it takes! After the server starts running at a given address, you can then update the `bore local` command with option `--to <ADDRESS>` to forward a local port to this remote server.
 
+It's possible to specify different IP addresses for the control server and for the tunnels. This setup is useful for cases where you might want the control server to be on a private network while allowing tunnel connections over a public interface, or vice versa.
+
 The full options for the `bore server` command are shown below.
 
 ```shell
@@ -93,10 +95,13 @@ Runs the remote proxy server
 Usage: bore server [OPTIONS]
 
 Options:
-      --min-port <MIN_PORT>  Minimum accepted TCP port number [default: 1024, env: BORE_MIN_PORT]
-      --max-port <MAX_PORT>  Maximum accepted TCP port number [default: 65535, env: BORE_MAX_PORT]
-  -s, --secret <SECRET>      Optional secret for authentication [env: BORE_SECRET]
-  -h, --help                 Print help information
+      --min-port <MIN_PORT>          Minimum accepted TCP port number [env: BORE_MIN_PORT=] [default: 1024]
+      --max-port <MAX_PORT>          Maximum accepted TCP port number [env: BORE_MAX_PORT=] [default: 65535]
+  -s, --secret <SECRET>              Optional secret for authentication [env: BORE_SECRET]
+      --control-addr <CONTROL_ADDR>  IP address for the control server. Bore clients must reach this address [default: 0.0.0.0]
+      --tunnels-addr <TUNNELS_ADDR>  IP address where tunnels will listen on [default: 0.0.0.0]
+  -h, --help                         Print help
+
 ```
 
 ## Protocol

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,13 +49,13 @@ enum Command {
         #[clap(short, long, env = "BORE_SECRET", hide_env_values = true)]
         secret: Option<String>,
 
-        /// IP address for the control server. Bore clients must reach this address.
+        /// IP address where the control server will bind to. Bore clients must reach this.
         #[clap(long, default_value = "0.0.0.0")]
-        control_addr: String,
+        bind_addr: String,
 
         /// IP address where tunnels will listen on.
         #[clap(long, default_value = "0.0.0.0")]
-        tunnels_addr: String,
+        bind_tunnels: String,
     },
 }
 
@@ -76,8 +76,8 @@ async fn run(command: Command) -> Result<()> {
             min_port,
             max_port,
             secret,
-            control_addr,
-            tunnels_addr,
+            bind_addr,
+            bind_tunnels,
         } => {
             let port_range = min_port..=max_port;
             if port_range.is_empty() {
@@ -86,14 +86,14 @@ async fn run(command: Command) -> Result<()> {
                     .exit();
             }
 
-            let ipaddr_control = control_addr.parse::<IpAddr>();
+            let ipaddr_control = bind_addr.parse::<IpAddr>();
             if ipaddr_control.is_err() {
                 Args::command()
                     .error(ErrorKind::InvalidValue, "invalid ip address for control server")
                     .exit();
             }
 
-            let ipaddr_tunnels = tunnels_addr.parse::<IpAddr>();
+            let ipaddr_tunnels = bind_tunnels.parse::<IpAddr>();
             if ipaddr_tunnels.is_err() {
                 Args::command()
                     .error(ErrorKind::InvalidValue, "invalid ip address for tunnel connections")

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,6 +51,10 @@ enum Command {
         /// IP address for the control server. Bore clients must reach this address.
         #[clap(long, default_value = "0.0.0.0")]
         control_addr: String,
+
+        /// IP address where tunnels will listen on.
+        #[clap(long, default_value = "0.0.0.0")]
+        tunnels_addr: String,
     },
 }
 
@@ -72,6 +76,7 @@ async fn run(command: Command) -> Result<()> {
             max_port,
             secret,
             control_addr,
+            tunnels_addr,
         } => {
             let port_range = min_port..=max_port;
             if port_range.is_empty() {
@@ -79,7 +84,7 @@ async fn run(command: Command) -> Result<()> {
                     .error(ErrorKind::InvalidValue, "port range is empty")
                     .exit();
             }
-            Server::new(port_range, secret.as_deref(), control_addr).listen().await?;
+            Server::new(port_range, secret.as_deref(), control_addr, tunnels_addr).listen().await?;
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,13 +49,13 @@ enum Command {
         #[clap(short, long, env = "BORE_SECRET", hide_env_values = true)]
         secret: Option<String>,
 
-        /// IP address where the control server will bind to. Bore clients must reach this.
+        /// IP address to bind to. Bore clients must reach this.
         #[clap(long, default_value = "0.0.0.0")]
         bind_addr: String,
 
-        /// IP address where tunnels will listen on.
-        #[clap(long, default_value = "0.0.0.0")]
-        bind_tunnels: String,
+        /// IP address where tunnels will listen on. Defaults to --bind-addr.
+        #[clap(long)]
+        bind_tunnels: Option<String>,
     },
 }
 
@@ -93,7 +93,7 @@ async fn run(command: Command) -> Result<()> {
                     .exit();
             }
 
-            let ipaddr_tunnels = bind_tunnels.parse::<IpAddr>();
+            let ipaddr_tunnels = bind_tunnels.unwrap_or(bind_addr).parse::<IpAddr>();
             if ipaddr_tunnels.is_err() {
                 Args::command()
                     .error(ErrorKind::InvalidValue, "invalid ip address for tunnel connections")

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,6 +47,10 @@ enum Command {
         /// Optional secret for authentication.
         #[clap(short, long, env = "BORE_SECRET", hide_env_values = true)]
         secret: Option<String>,
+
+        /// IP address for the control server. Bore clients must reach this address.
+        #[clap(long, default_value = "0.0.0.0")]
+        control_addr: String,
     },
 }
 
@@ -67,6 +71,7 @@ async fn run(command: Command) -> Result<()> {
             min_port,
             max_port,
             secret,
+            control_addr,
         } => {
             let port_range = min_port..=max_port;
             if port_range.is_empty() {
@@ -74,7 +79,7 @@ async fn run(command: Command) -> Result<()> {
                     .error(ErrorKind::InvalidValue, "port range is empty")
                     .exit();
             }
-            Server::new(port_range, secret.as_deref()).listen().await?;
+            Server::new(port_range, secret.as_deref(), control_addr).listen().await?;
         }
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -54,7 +54,7 @@ impl Server {
     pub async fn listen(self) -> Result<()> {
         let this = Arc::new(self);
         let listener = TcpListener::bind((this.bind_addr, CONTROL_PORT)).await?;
-        info!(addr = ?this.bind_addr, "server listening");
+        info!(addr = ?this.bind_addr, port = CONTROL_PORT, "server listening");
 
         loop {
             let (stream, addr) = listener.accept().await?;
@@ -133,8 +133,9 @@ impl Server {
                         return Ok(());
                     }
                 };
+                let host = listener.local_addr()?.ip();
                 let port = listener.local_addr()?.port();
-                info!(?port, "new client");
+                info!(?host, ?port, "new client");
                 stream.send(ServerMessage::Hello(port)).await?;
 
                 loop {

--- a/tests/e2e_test.rs
+++ b/tests/e2e_test.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::items_after_test_module)]
 
 use std::net::SocketAddr;
+use std::net::IpAddr;
 use std::time::Duration;
 
 use anyhow::{anyhow, Result};
@@ -23,8 +24,8 @@ async fn spawn_server(secret: Option<&str>) {
         Server::new(
             1024..=65535,
             secret,
-            "0.0.0.0".to_string(),
-            "0.0.0.0".to_string(),
+            "0.0.0.0".parse::<IpAddr>().unwrap(),
+            "0.0.0.0".parse::<IpAddr>().unwrap(),
         )
         .listen(),
     );
@@ -136,7 +137,7 @@ fn empty_port_range() {
     let _ = Server::new(
         min_port..=max_port,
         None,
-        "0.0.0.0".to_string(),
-        "0.0.0.0".to_string(),
+        "0.0.0.0".parse::<IpAddr>().unwrap(),
+        "0.0.0.0".parse::<IpAddr>().unwrap(),
     );
 }

--- a/tests/e2e_test.rs
+++ b/tests/e2e_test.rs
@@ -19,7 +19,15 @@ lazy_static! {
 
 /// Spawn the server, giving some time for the control port TcpListener to start.
 async fn spawn_server(secret: Option<&str>) {
-    tokio::spawn(Server::new(1024..=65535, secret).listen());
+    tokio::spawn(
+        Server::new(
+            1024..=65535,
+            secret,
+            "0.0.0.0".to_string(),
+            "0.0.0.0".to_string(),
+        )
+        .listen(),
+    );
     time::sleep(Duration::from_millis(50)).await;
 }
 
@@ -125,5 +133,10 @@ async fn very_long_frame() -> Result<()> {
 fn empty_port_range() {
     let min_port = 5000;
     let max_port = 3000;
-    let _ = Server::new(min_port..=max_port, None);
+    let _ = Server::new(
+        min_port..=max_port,
+        None,
+        "0.0.0.0".to_string(),
+        "0.0.0.0".to_string(),
+    );
 }


### PR DESCRIPTION
I've added the option to bind to the given IP address for both the control server and the tunnels, which may be different. Previously both were hardcoded to listen on `0.0.0.0`.

A new `--control-addr` flag allows users to specify the IP address where the control server will listen on. Likewise for `--tunnels-addr` allowing users to define the IP address on which tunnels will listen.

Its now possible to isolate the control server from the tunnel's network. One could perhaps have the control server on a `tailscale0` interface while the tunnels listen on `eth0` on a public IP.

I have already tested bore with this change to redirect a nginx instance (server @ `10.0.0.95:80`) via tailscale (control @ `100.64.0.3`) into another interface (tunnel @ `192.168.30.100`) and it works fine on my machines.

