### PR TITLE
Enable json logging

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ use clap::{error::ErrorKind, CommandFactory, Parser, Subcommand};
 struct Args {
     #[clap(subcommand)]
     command: Command,
-    #[clap(short, long)]
+    #[clap(long)]
     log: bool,
 }
 


### PR DESCRIPTION
Add JSON-formatted logging to log.json when -l or --log flag is passed

- Enable event logging in JSON format only if the logging flag is provided.
- Save the logs in a file named log.json.
