### PR TITLE
Implement systemd socket activation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,6 +123,7 @@ dependencies = [
  "hex",
  "hmac",
  "lazy_static",
+ "listenfd",
  "rstest",
  "serde",
  "serde_json",
@@ -483,6 +484,17 @@ name = "linux-raw-sys"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e8776872cdc2f073ccaab02e336fa321328c1e02646ebcb9d2108d0baab480d"
+
+[[package]]
+name = "listenfd"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b87bc54a4629b4294d0b3ef041b64c40c611097a677d9dc07b2c67739fe39dba"
+dependencies = [
+ "libc",
+ "uuid",
+ "winapi",
+]
 
 [[package]]
 name = "lock_api"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ tokio-util = { version = "0.7.1", features = ["codec"] }
 tracing = "0.1.32"
 tracing-subscriber = "0.3.18"
 uuid = { version = "1.2.1", features = ["serde", "v4"] }
+listenfd = "1.0.2"
 
 [dev-dependencies]
 lazy_static = "1.4.0"

--- a/src/server.rs
+++ b/src/server.rs
@@ -5,6 +5,7 @@ use std::{io, ops::RangeInclusive, sync::Arc, time::Duration};
 
 use anyhow::Result;
 use dashmap::DashMap;
+use listenfd::ListenFd;
 use tokio::io::AsyncWriteExt;
 use tokio::net::{TcpListener, TcpStream};
 use tokio::time::{sleep, timeout};
@@ -58,7 +59,16 @@ impl Server {
     /// Start the server, listening for new connections.
     pub async fn listen(self) -> Result<()> {
         let this = Arc::new(self);
-        let listener = TcpListener::bind((this.bind_addr, CONTROL_PORT)).await?;
+
+        let mut listenfd = ListenFd::from_env();
+        let listener = if let Some(sd_listener) = listenfd.take_tcp_listener(0)? {
+            // Handle socket passed through socket activation mechanism
+            TcpListener::from_std(sd_listener)?
+        } else {
+            // "Normal" mode (no socket passed, bore handle its creation)
+            TcpListener::bind((this.bind_addr, CONTROL_PORT)).await?
+        };
+
         info!(addr = ?this.bind_addr, "server listening");
 
         loop {


### PR DESCRIPTION
This PR implements systemd socket activation using [listenfd](https://docs.rs/listenfd/latest/listenfd/) crate.

If you're not familiar with systemd socket activation, I recommend reading these two blog posts that underline its goals and how it operates:
- https://ilmanzo.github.io/post/systemd-socket-activated-services/
- https://0pointer.de/blog/projects/socket-activation.html

You can quickly test the behaviour with these two unit files:
```ini
# bore.socket
[Unit]
Description=Bore Control Socket

[Socket]
ListenStream=7835
KeepAlive=true

[Install]
WantedBy=sockets.target
```

```ini
# bore.service
[Unit]
Description=Bore Server
Requires=bore.socket
After=network.target

[Service]
Type=simple
ExecStart=/usr/local/bin/bore server --min-port 5000 --max-port 6000
Restart=always

[Install]
WantedBy=multi-user.target
```

In the event you're interested in merging this PR, I'll be happy to contribute more detailed documentation and examples on how to integrate with systemd.