### PR TITLE
Add QR rendering to bore local

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,6 +123,7 @@ dependencies = [
  "hex",
  "hmac",
  "lazy_static",
+ "qrcode",
  "rstest",
  "serde",
  "serde_json",
@@ -133,6 +134,18 @@ dependencies = [
  "tracing-subscriber",
  "uuid",
 ]
+
+[[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
@@ -429,6 +442,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -531,6 +556,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -538,6 +573,15 @@ checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
  "winapi",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -603,6 +647,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "pxfm"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
+
+[[package]]
+name = "qrcode"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d68782463e408eb1e668cf6152704bd856c78c5b6417adaee3203d8f4c1fc9ec"
+dependencies = [
+ "image",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ tokio = { version = "1.17.0", features = ["rt-multi-thread", "io-util", "macros"
 tokio-util = { version = "0.7.1", features = ["codec"] }
 tracing = "0.1.32"
 tracing-subscriber = "0.3.18"
+qrcode = "0.14.1"
 uuid = { version = "1.2.1", features = ["serde", "v4"] }
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ You can forward a port on your local machine by using the `bore local` command. 
 bore local 5000 --to bore.pub
 ```
 
-You can optionally pass in a `--port` option to pick a specific port on the remote to expose, although the command will fail if this port is not available. Also, passing `--local-host` allows you to expose a different host on your local area network besides the loopback address `localhost`.
+You can optionally pass in a `--port` option to pick a specific port on the remote to expose, although the command will fail if this port is not available. Also, passing `--local-host` allows you to expose a different host on your local area network besides the loopback address `localhost`. By default, bore renders a QR code for the public URL in the console; pass `--no-qr` to disable it.
 
 The full options are shown below.
 
@@ -99,6 +99,7 @@ Options:
   -l, --local-host <HOST>  The local host to expose [default: localhost]
   -t, --to <TO>            Address of the remote server to expose local ports to [env: BORE_SERVER=]
   -p, --port <PORT>        Optional port on the remote server to select [default: 0]
+  --no-qr                  Disable QR code rendering
   -s, --secret <SECRET>    Optional secret for authentication [env: BORE_SECRET]
   -h, --help               Print help
 ```

--- a/src/client.rs
+++ b/src/client.rs
@@ -8,6 +8,7 @@ use tracing::{error, info, info_span, warn, Instrument};
 use uuid::Uuid;
 
 use crate::auth::Authenticator;
+use crate::qrcode;
 use crate::shared::{ClientMessage, Delimited, ServerMessage, CONTROL_PORT, NETWORK_TIMEOUT};
 
 /// State structure for the client.
@@ -39,6 +40,7 @@ impl Client {
         to: &str,
         port: u16,
         secret: Option<&str>,
+        qr: bool,
     ) -> Result<Self> {
         let mut stream = Delimited::new(connect_with_timeout(to, CONTROL_PORT).await?);
         let auth = secret.map(Authenticator::new);
@@ -58,6 +60,12 @@ impl Client {
         };
         info!(remote_port, "connected to server");
         info!("listening at {to}:{remote_port}");
+        if qr {
+            let url = format!("http://{to}:{remote_port}");
+            for line in qrcode::render(&url)? {
+                info!("{line}");
+            }
+        }
 
         Ok(Client {
             conn: Some(stream),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,5 +17,6 @@
 
 pub mod auth;
 pub mod client;
+pub mod qrcode;
 pub mod server;
 pub mod shared;

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,10 @@ enum Command {
         /// Optional secret for authentication.
         #[clap(short, long, env = "BORE_SECRET", hide_env_values = true)]
         secret: Option<String>,
+
+        /// Render a QR code for the public URL in the console.
+        #[clap(long, default_value_t = false)]
+        qr: bool,
     },
 
     /// Runs the remote proxy server.
@@ -69,8 +73,10 @@ async fn run(command: Command) -> Result<()> {
             to,
             port,
             secret,
+            qr,
         } => {
-            let client = Client::new(&local_host, local_port, &to, port, secret.as_deref()).await?;
+            let client = Client::new(&local_host, local_port, &to, port, secret.as_deref(), qr)
+                .await?;
             client.listen().await?;
         }
         Command::Server {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use std::net::IpAddr;
 
 use anyhow::Result;
 use bore_cli::{client::Client, server::Server};
-use clap::{error::ErrorKind, CommandFactory, Parser, Subcommand};
+use clap::{error::ErrorKind, ArgAction, CommandFactory, Parser, Subcommand};
 
 #[derive(Parser, Debug)]
 #[clap(author, version, about)]
@@ -35,8 +35,8 @@ enum Command {
         #[clap(short, long, env = "BORE_SECRET", hide_env_values = true)]
         secret: Option<String>,
 
-        /// Render a QR code for the public URL in the console.
-        #[clap(long, default_value_t = false)]
+        /// Disable rendering a QR code for the public URL in the console.
+        #[clap(long = "no-qr", action = ArgAction::SetFalse, default_value_t = true)]
         qr: bool,
     },
 

--- a/src/qrcode.rs
+++ b/src/qrcode.rs
@@ -1,6 +1,9 @@
+//! QR code rendering helpers for console output.
+
 use anyhow::Result;
 use qrcode::{render::unicode, QrCode};
 
+/// Render a text payload as console-safe QR code lines.
 pub fn render(text: &str) -> Result<Vec<String>> {
     let qr = QrCode::new(text.as_bytes())?
         .render::<unicode::Dense1x2>()

--- a/src/qrcode.rs
+++ b/src/qrcode.rs
@@ -1,0 +1,10 @@
+use anyhow::Result;
+use qrcode::{render::unicode, QrCode};
+
+pub fn render(text: &str) -> Result<Vec<String>> {
+    let qr = QrCode::new(text.as_bytes())?
+        .render::<unicode::Dense1x2>()
+        .quiet_zone(false)
+        .build();
+    Ok(qr.lines().map(str::to_owned).collect())
+}

--- a/tests/e2e_test.rs
+++ b/tests/e2e_test.rs
@@ -25,7 +25,7 @@ async fn spawn_server(secret: Option<&str>) {
 async fn spawn_client(secret: Option<&str>) -> Result<(TcpListener, SocketAddr)> {
     let listener = TcpListener::bind("localhost:0").await?;
     let local_port = listener.local_addr()?.port();
-    let client = Client::new("localhost", local_port, "localhost", 0, secret).await?;
+    let client = Client::new("localhost", local_port, "localhost", 0, secret, false).await?;
     let remote_addr = ([127, 0, 0, 1], client.remote_port()).into();
     tokio::spawn(client.listen());
     Ok((listener, remote_addr))
@@ -84,7 +84,7 @@ async fn mismatched_secret(
 async fn invalid_address() -> Result<()> {
     // We don't need the serial guard for this test because it doesn't create a server.
     async fn check_address(to: &str, use_secret: bool) -> Result<()> {
-        match Client::new("localhost", 5000, to, 0, use_secret.then_some("a secret")).await {
+        match Client::new("localhost", 5000, to, 0, use_secret.then_some("a secret"), false).await {
             Ok(_) => Err(anyhow!("expected error for {to}, use_secret={use_secret}")),
             Err(_) => Ok(()),
         }


### PR DESCRIPTION
This PR adds optional QR code output to improve how users share bore local tunnel URLs.

- **New behavior**: When a tunnel is created, a QR code for the public URL is rendered directly in the console (enabled by default).
- **Opt-out**: A new --no-qr CLI flag disables this behavior for users who don’t want the extra output.
- **Implementation**: Introduces a small qrcode module (backed by the qrcode crate) and threads a qr: bool flag through Client::new and its call sites to control rendering.
- **CLI & docs**: Updates argument parsing, help text, and README to document the new feature and flag.

Overall, this is a lightweight, backwards-compatible UX improvement that makes sharing tunnel links much easier, especially when testing on on mobile devices.

Before a merge, be sure to consider the consent model; right now this is opt-in as I think that this is a valuable feature to push, but it could be breaking depending on how users are implementing bore. 


https://github.com/user-attachments/assets/1c8be887-6feb-4913-8ea9-b953730bcdcd

